### PR TITLE
exposing Spectra2DExtended struct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ Query = "1a8c2f83-1ff3-5112-b086-8aa67b057ba1"
 RvSpectMLBase = "c48404b2-35ea-40e7-ac7f-06a53de703d6"
 
 [compat]
-CSV = "0.7, 0.8"
+CSV = "0.7, 0.8, 0.9"
 DataFrames = "0.21, 0.22, 1.0, 1.1"
 FITSIO = "0.16"
 Interpolations = "0.12, 0.13"

--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-CSV = "0.7, 0.8, 0.9"
+CSV = "0.7, 0.8, 0.9, 0.10"
 DataFrames = "0.21, 0.22, 1.0, 1.1"
 FITSIO = "0.16"
 Interpolations = "0.12, 0.13"


### PR DESCRIPTION
This allows for the Spectra2DExtended from RvSpectMLBase to be gotten by the user if they pass the return_λ_obs keyword to read_data()