### PR TITLE
passing all kwargs in neid's read_data()

### DIFF
--- a/src/neid/io.jl
+++ b/src/neid/io.jl
@@ -245,9 +245,9 @@ function read_data(fn::String, metadata::Dict{Symbol,Any}; kwargs...)
     read_data(f, metadata; kwargs...)
 end
 
-function read_data(fn::String, metadata::Dict{Symbol,Any}, orders_to_read::AR; normalization::Symbol = :raw  )  where  { AR<:AbstractRange }
+function read_data(fn::String, metadata::Dict{Symbol,Any}, orders_to_read::AR; kwargs...)  where  { AR<:AbstractRange }
     f = FITS(fn)
-    read_data(f, metadata, orders_to_read, normalization=normalization)
+    read_data(f, metadata, orders_to_read; kwargs...)
 end
 
 function read_data(fn::String; normalization::Symbol = :raw, kwargs...)


### PR DESCRIPTION
Sorry, I should have caught this earlier. Also might want to fix the "specific" typo in the about section